### PR TITLE
feat: React-Popupbox Close Confirm 

### DIFF
--- a/src/lib/manager.js
+++ b/src/lib/manager.js
@@ -43,6 +43,13 @@ class Manager extends EventEmitter {
   }
 
   close() {
+    if (this.config.confirmClose) {
+      if (this.config.confirmClose()) {
+        this.show = false;
+        this.emitChange();
+      }
+      return
+    }
     this.show = false
     this.emitChange()
   }


### PR DESCRIPTION
**Problem:** 
Today, the popupbox don't have a way to confirm or cancel the close action. [#19 ]

**What this PR do?**
Run a callback function declared through config, to confirm the close action.

**Ex:**
`PopupboxManager.config.confirmClose = () => window.confirm('Are you sure?')`

**Why:**
To prevent accidental loss of data in a popupbox with forms.