### PR TITLE
Move componentWillMount to constructor since it is deprecated

### DIFF
--- a/src/lib/container.js
+++ b/src/lib/container.js
@@ -11,6 +11,8 @@ export class Container extends Component {
     Manager.setDefault(this._defaultState)
 
     this.handleStoreChange = this.handleStoreChange.bind(this)
+    Manager.addChangeListener(this.handleStoreChange)
+
     this.closeImagebox = Manager.close.bind(Manager)
   }
 
@@ -43,10 +45,6 @@ export class Container extends Component {
     if (this.state.show && (e.keyCode === 27)) {
       this.closeImagebox()
     }
-  }
-
-  componentWillMount() {
-    Manager.addChangeListener(this.handleStoreChange)
   }
 
   componentDidMount() {
@@ -133,22 +131,22 @@ export class Container extends Component {
         style={{ transition: this.state.transition }}
         className={`popupbox${show ? ' is-active': ''}`}
       >
-        <div 
+        <div
           className={`popupbox-wrapper${className ? ` ${className}` : ''}`}
           style={style ? style : undefined}
         >
           { titleBar.enable && this.renderTitleBar() }
-          <div 
+          <div
             className={`popupbox-content${content.className ? ` ${content.className}` : ''}`}
             style={content.style ? content.style : undefined}
           >
             { children }
           </div>
         </div>
-        <div 
-          className="popupbox-overlay" 
-          style={{ opacity: overlayOpacity }} 
-          onClick={this.state.overlayClose ? this.closeImagebox : undefined} 
+        <div
+          className="popupbox-overlay"
+          style={{ opacity: overlayOpacity }}
+          onClick={this.state.overlayClose ? this.closeImagebox : undefined}
         />
       </div>
     )


### PR DESCRIPTION
React gives the following warning:

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Container
```

Since the `componentWillMount` code just sets an event handler and doesn't (to my knowledge) have side effects, it seemed like the constructor was the more appropriate place.